### PR TITLE
Ensure hall movement drags attached items

### DIFF
--- a/RG_Tag_Mapper.py
+++ b/RG_Tag_Mapper.py
@@ -534,9 +534,13 @@ class HallItem(QGraphicsRectItem):
                 new.setY(round(new.y()/step)*step)
             delta = new - self.pos()
             if not delta.isNull():
-                for child in self.childItems():
-                    if isinstance(child, RectZoneItem):
-                        child.moveBy(-delta.x(), -delta.y())
+                scene = self.scene()
+                if scene:
+                    mw = getattr(scene, "mainwindow", None)
+                    if mw:
+                        for anchor in mw.anchors:
+                            if anchor.main_hall_number == self.number or self.number in anchor.extra_halls:
+                                anchor.moveBy(delta.x(), delta.y())
             return new
         return super().itemChange(change, value)
 


### PR DESCRIPTION
## Summary
- move anchors associated with a hall when the hall is repositioned
- rely on parent-child transforms so hall zones travel with the hall instead of staying in place

## Testing
- python3 -m compileall RG_Tag_Mapper.py

------
https://chatgpt.com/codex/tasks/task_e_68d3e8db2afc83319ec2f2ec449850d1