### PR TITLE
Отображение трека для переходных зон

### DIFF
--- a/RG_Tag_Mapper.py
+++ b/RG_Tag_Mapper.py
@@ -935,6 +935,21 @@ class RectZoneItem(QGraphicsRectItem):
         audio_info = None
         if isinstance(hall, HallItem):
             audio_info = hall.zone_audio_tracks.get(self.zone_num)
+        if (
+            not audio_info
+            and self.zone_type in ("Переходная", "Переходная зона")
+            and mw
+        ):
+            for candidate in mw.halls:
+                same_number = candidate.number == self.zone_num
+                if not same_number:
+                    try:
+                        same_number = int(candidate.number) == int(self.zone_num)
+                    except (TypeError, ValueError):
+                        same_number = False
+                if same_number and candidate.audio_settings:
+                    audio_info = candidate.audio_settings
+                    break
         if audio_info:
             audio_line = format_audio_menu_line(audio_info)
             if audio_line:


### PR DESCRIPTION
## Summary
- показываем аудиотрек в контекстном меню переходной зоны, если у зала с таким же номером есть трек

## Testing
- python -m compileall RG_Tag_Mapper.py

------
https://chatgpt.com/codex/tasks/task_e_68d50726ab0083318a83ab458791bb99