### PR TITLE
Increase toolbar button size

### DIFF
--- a/RG_Tag_Mapper.py
+++ b/RG_Tag_Mapper.py
@@ -1588,7 +1588,12 @@ class PlanEditorMainWindow(QMainWindow):
         help_menu.addAction(self.action_about)
 
     def _create_toolbars(self):
-        icon_size = QSize(48, 48)
+        base_icon_size = QSize(48, 48)
+        scale_factor = 1.2
+        icon_size = QSize(
+            int(round(base_icon_size.width() * scale_factor)),
+            int(round(base_icon_size.height() * scale_factor)),
+        )
 
         file_toolbar = QToolBar("Файл", self)
         file_toolbar.setToolButtonStyle(Qt.ToolButtonIconOnly)


### PR DESCRIPTION
## Summary
- увеличить исходный размер иконок на панели инструментов на 20%, масштабируя базовый размер 48×48 до 58×58 пикселей

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d510519b008331a56935bd468d3f6f