### PR TITLE
Добавить отступы вокруг рабочей области

### DIFF
--- a/RG_Tag_Mapper.py
+++ b/RG_Tag_Mapper.py
@@ -1404,7 +1404,13 @@ class PlanEditorMainWindow(QMainWindow):
         self.view = MyGraphicsView(self.scene)
         self.view.setRenderHint(QPainter.Antialiasing)
         self.view.setViewportUpdateMode(QGraphicsView.FullViewportUpdate)
-        self.setCentralWidget(self.view)
+
+        central_widget = QWidget()
+        central_layout = QVBoxLayout(central_widget)
+        margin = 12
+        central_layout.setContentsMargins(margin, margin, margin, margin)
+        central_layout.addWidget(self.view)
+        self.setCentralWidget(central_widget)
 
         self.tree = QTreeWidget(); self.tree.setHeaderLabel("Объекты"); self.tree.setWordWrap(True)
         self.tree.setContextMenuPolicy(Qt.CustomContextMenu)


### PR DESCRIPTION
## Summary
- обернул QGraphicsView в центральный виджет с вертикальным макетом
- добавил равномерные внешние отступы, чтобы рабочая область не прилегала к краям окна

## Testing
- python -m py_compile RG_Tag_Mapper.py

------
https://chatgpt.com/codex/tasks/task_e_68d5132869248331bcce4b69e18ebd3b