### PR TITLE
Add Markdown support to help dialog

### DIFF
--- a/RG_Tag_Mapper.py
+++ b/RG_Tag_Mapper.py
@@ -2177,7 +2177,11 @@ class PlanEditorMainWindow(QMainWindow):
         layout = QVBoxLayout(dialog)
 
         browser = QTextBrowser(dialog)
-        browser.setPlainText(text)
+        if hasattr(browser, "setMarkdown"):
+            browser.setMarkdown(text)
+        else:
+            browser.setPlainText(text)
+        browser.setOpenExternalLinks(True)
         layout.addWidget(browser)
 
         buttons = QDialogButtonBox(QDialogButtonBox.Close, parent=dialog)


### PR DESCRIPTION
## Summary
- update the help dialog to render the loaded README with Markdown formatting
- allow the help viewer to open external links from the documentation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6670b2274833194f84d49111285d2