### PR TITLE
Add paramiko-ppk dependency for PPK key support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ matplotlib==3.10.1
 numpy==2.2.3
 packaging==24.2
 paramiko==3.5.0
+paramiko-ppk==1.2.3
 pefile==2023.2.7
 pillow==11.1.0
 pyinstaller==6.12.0


### PR DESCRIPTION
## Summary
- add the paramiko-ppk dependency so the bundled client can import paramiko.ppk for PPK key uploads

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6708eb4d48331bf3d569c396ffeb3